### PR TITLE
FetchTools refactoring

### DIFF
--- a/src/features/abort/abort-util.ts
+++ b/src/features/abort/abort-util.ts
@@ -17,14 +17,14 @@ export function mergeSignals(...signals: AbortSignal[]): AbortTools {
   for (const signal of signals) {
     if (signal.aborted) {
       checkSignalAndAbort(signal, abortCtrl);
-      return { signal, abortCtrl };
+      return { signal, ctrl: abortCtrl };
     }
     signal.addEventListener('abort', function (_ev: Event) {
       checkSignalAndAbort(this, abortCtrl);
     }, { once: true, signal: abortCtrl.signal });
   }
 
-  return { signal: abortCtrl.signal, abortCtrl };
+  return { signal: abortCtrl.signal, ctrl: abortCtrl };
 }
 
 function checkSignalAndAbort(signal: AbortSignal, abortCtrl: AbortController): void {

--- a/src/features/abort/abort-util.ts
+++ b/src/features/abort/abort-util.ts
@@ -1,5 +1,4 @@
 import { createError } from 'thror';
-import type { AbortTools } from './models/abort.model';
 
 export function defaultSignal(): AbortSignal {
   return new AbortController().signal;
@@ -11,20 +10,20 @@ export function timedSignal(timeoutMs: number): AbortSignal {
   return signal;
 }
 
-export function mergeSignals(...signals: AbortSignal[]): AbortTools {
+export function mergeSignals(...signals: AbortSignal[]): AbortController {
   const abortCtrl: AbortController = new AbortController();
 
   for (const signal of signals) {
     if (signal.aborted) {
       checkSignalAndAbort(signal, abortCtrl);
-      return { signal, ctrl: abortCtrl };
+      return abortCtrl;
     }
-    signal.addEventListener('abort', function (_ev: Event) {
+    signal.addEventListener('abort', function () {
       checkSignalAndAbort(this, abortCtrl);
     }, { once: true, signal: abortCtrl.signal });
   }
 
-  return { signal: abortCtrl.signal, ctrl: abortCtrl };
+  return abortCtrl;
 }
 
 function checkSignalAndAbort(signal: AbortSignal, abortCtrl: AbortController): void {

--- a/src/features/abort/models/abort.model.ts
+++ b/src/features/abort/models/abort.model.ts
@@ -1,4 +1,4 @@
 export interface AbortTools {
   signal: AbortSignal;
-  abortCtrl: AbortController;
+  ctrl: AbortController;
 }

--- a/src/features/abort/models/abort.model.ts
+++ b/src/features/abort/models/abort.model.ts
@@ -1,4 +1,0 @@
-export interface AbortTools {
-  signal: AbortSignal;
-  ctrl: AbortController;
-}

--- a/src/features/interceptors/interceptors-util.ts
+++ b/src/features/interceptors/interceptors-util.ts
@@ -23,26 +23,16 @@ export function mergeInterceptors(defaultInterceptors: Partial<Interceptors>, in
     beforeFinish: () => {
       defaultInterceptors.beforeFinish?.();
       interceptors.beforeFinish?.();
-    }
+    },
   };
 }
 
 export function initInterceptors(interceptors: Partial<Interceptors>): Interceptors {
   return {
-    beforeConsume: (request: HttpRequest) => {
-      interceptors.beforeConsume?.(request);
-    },
-    afterConsume: (request: HttpRequest, response: Response) => {
-      interceptors.afterConsume?.(request, response);
-    },
-    beforeResult: (result: unknown) => {
-      interceptors.beforeResult?.(result);
-    },
-    beforeError: (errorResponse: HttpErrorResponse) => {
-      interceptors.beforeError?.(errorResponse);
-    },
-    beforeFinish: () => {
-      interceptors.beforeFinish?.();
-    }
+    beforeConsume: (request: HttpRequest) => interceptors.beforeConsume?.(request),
+    afterConsume: (request: HttpRequest, response: Response) => interceptors.afterConsume?.(request, response),
+    beforeResult: (result: unknown) => interceptors.beforeResult?.(result),
+    beforeError: (errorResponse: HttpErrorResponse) => interceptors.beforeError?.(errorResponse),
+    beforeFinish: () => interceptors.beforeFinish?.(),
   };
 }

--- a/src/features/progress/download-progress.ts
+++ b/src/features/progress/download-progress.ts
@@ -1,6 +1,6 @@
 import { emitError } from 'thror';
 import type { Nullable } from '../../models/shared.model';
-import type { FetchTools } from '../../request/fetching';
+import type { FetchTools } from '../../request/models/fetch-tools.model';
 import { now as dateNow } from '../../utils/date-util';
 
 export async function inspectDownloadProgress(response: Response, tools: FetchTools): Promise<void> {
@@ -20,7 +20,7 @@ export async function inspectDownloadProgress(response: Response, tools: FetchTo
   let reminder: number = dateNow();
 
   for (let i = 1; ; i ++) {
-    if (tools.abortTools.signal.aborted) return;
+    if (tools.abort.signal.aborted) return;
 
     const { done, value: chunk = new Uint8Array(0) }: ReadableStreamReadResult<Uint8Array> = await reader.read();
     if (done) break;

--- a/src/features/progress/download-progress.ts
+++ b/src/features/progress/download-progress.ts
@@ -20,7 +20,7 @@ export async function inspectDownloadProgress(response: Response, tools: FetchTo
   let reminder: number = dateNow();
 
   for (let i = 1; ; i ++) {
-    if (tools.abort.signal.aborted) return;
+    if (tools.abortCtrl.signal.aborted) return;
 
     const { done, value: chunk = new Uint8Array(0) }: ReadableStreamReadResult<Uint8Array> = await reader.read();
     if (done) break;

--- a/src/request/fetching.ts
+++ b/src/request/fetching.ts
@@ -20,7 +20,7 @@ export async function performHttpRequest<T>(request: HttpRequest, tools: FetchTo
       ? await fetchResponse.json()
       : await fetchResponse.text();
 
-    if (needRetry(tools.retry, status, request.method, retried, tools.abort.ctrl)) {
+    if (needRetry(tools.retry, status, request.method, retried, tools.abortCtrl)) {
 
       const delay: number = (tools.retry.withRetryAfter && getRetryAfter(headers)) || tools.retry.withDelayMs;
       if (delay) await sleep(delay);
@@ -28,7 +28,7 @@ export async function performHttpRequest<T>(request: HttpRequest, tools: FetchTo
       retried ++;
 
       tools.retryCb?.({
-        abort: (reason?: any) => tools.abort.ctrl.abort(reason),
+        abort: (reason?: any) => tools.abortCtrl.abort(reason),
         count: retried,
         delay,
         error,
@@ -78,7 +78,7 @@ function performFetch(request: HttpRequest, tools: FetchTools): Promise<Response
   const fetchOptions: RequestInit & { duplex?: 'half' } = {
     method,
     headers,
-    signal: tools.abort.signal,
+    signal: tools.abortCtrl.signal,
   };
 
   if (requestBody) {

--- a/src/request/models/fetch-tools.model.ts
+++ b/src/request/models/fetch-tools.model.ts
@@ -1,11 +1,10 @@
-import type { AbortTools } from '../../features/abort/models/abort.model';
 import type { Interceptors } from '../../features/interceptors/models/interceptor.model';
 import type { ProgressConfig } from '../../features/progress/models/progress-config.model';
 import type { InstanceRetryConfig } from '../../features/retry/models/retry-config.model';
 import type { Observer } from './request-controller.model';
 
 export interface FetchTools {
-  abort: AbortTools;
+  abortCtrl: AbortController;
   interceptors: Interceptors;
   retry: Required<InstanceRetryConfig>;
   retryCb?: Observer<unknown>['retry'];

--- a/src/request/models/fetch-tools.model.ts
+++ b/src/request/models/fetch-tools.model.ts
@@ -1,0 +1,15 @@
+import type { AbortTools } from '../../features/abort/models/abort.model';
+import type { Interceptors } from '../../features/interceptors/models/interceptor.model';
+import type { ProgressConfig } from '../../features/progress/models/progress-config.model';
+import type { InstanceRetryConfig } from '../../features/retry/models/retry-config.model';
+import type { Observer } from './request-controller.model';
+
+export interface FetchTools {
+  abort: AbortTools;
+  interceptors: Interceptors;
+  retry: Required<InstanceRetryConfig>;
+  retryCb?: Observer<unknown>['retry'];
+  progress: Required<ProgressConfig>;
+  dlCb?: Observer<unknown>['downloadProgress'];
+  // ulCb?: Observer<unknown>['uploadProgress'];
+}

--- a/src/request/models/request-controller.model.ts
+++ b/src/request/models/request-controller.model.ts
@@ -1,5 +1,4 @@
 import type { RetryEvent, StreamProgressEvent } from '../../features';
-import type { AbortTools } from '../../features/abort/models/abort.model';
 import type { Interceptors } from '../../features/interceptors/models/interceptor.model';
 import type { ProgressConfig } from '../../features/progress/models/progress-config.model';
 import type { InstanceRetryConfig } from '../../features/retry/models/retry-config.model';
@@ -15,7 +14,7 @@ export interface RequestControllerConfig extends Required<Omit<RequestConfig<any
   interceptors: Interceptors;
   retry: Required<InstanceRetryConfig>;
   progress: DeepRequired<ProgressConfig>;
-  abort: AbortTools;
+  abortCtrl: AbortController;
 }
 
 export type ObjectBody<T> = Exclude<Extract<T, object>, Blob | ArrayBuffer | FormData | HttpResponse<any>>

--- a/src/request/models/request-controller.model.ts
+++ b/src/request/models/request-controller.model.ts
@@ -15,7 +15,7 @@ export interface RequestControllerConfig extends Required<Omit<RequestConfig<any
   interceptors: Interceptors;
   retry: Required<InstanceRetryConfig>;
   progress: DeepRequired<ProgressConfig>;
-  abortTools: AbortTools;
+  abort: AbortTools;
 }
 
 export type ObjectBody<T> = Exclude<Extract<T, object>, Blob | ArrayBuffer | FormData | HttpResponse<any>>

--- a/src/request/request-controller.ts
+++ b/src/request/request-controller.ts
@@ -91,7 +91,7 @@ export class RequestController<Resource> {
     this.config.interceptors.beforeConsume(this.request);
 
     const tools: FetchTools = {
-      abort: this.config.abort,
+      abortCtrl: this.config.abortCtrl,
       interceptors: this.config.interceptors,
       retry: this.config.retry,
       retryCb: observer?.retry,
@@ -132,7 +132,7 @@ export class RequestController<Resource> {
         }
       })
       .catch((err: any) => {
-        if (this.config.abort.signal.aborted) return observer.abort?.(this.config.abort.signal.reason);
+        if (this.config.abortCtrl.signal.aborted) return observer.abort?.(this.config.abortCtrl.signal.reason);
         observer.error?.(err);
       })
       .finally(() => {
@@ -143,8 +143,8 @@ export class RequestController<Resource> {
 
   /** @internal */
   private catchable(thrown: any): Promise<any> {
-    const error: any = (this.config.abort.signal.aborted) ?
-      (this.config.abort.signal.abortedByTimeout) ? fixChromiumAndWebkitTimeoutError(thrown)
+    const error: any = (this.config.abortCtrl.signal.aborted) ?
+      (this.config.abortCtrl.signal.abortedByTimeout) ? fixChromiumAndWebkitTimeoutError(thrown)
         : fixFirefoxAbortError(thrown)
       : thrown;
 

--- a/src/request/request-controller.ts
+++ b/src/request/request-controller.ts
@@ -1,10 +1,10 @@
 import { fixChromiumAndWebkitTimeoutError, fixFirefoxAbortError } from '../features/abort/abort-util';
 import type { DrinoDefaultConfig } from '../models/drino.model';
 import type { RequestMethodType, Url } from '../models/http.model';
-import type { FetchTools } from './fetching';
 import { performHttpRequest } from './fetching';
 import { HttpRequest } from './http-request';
 import type { RequestConfig } from './models';
+import type { FetchTools } from './models/fetch-tools.model';
 import type { CheckCallback, FinalCallback, FollowCallback, Modifier, Observer, ReportCallback, RequestControllerConfig } from './models/request-controller.model';
 import { mergeRequestConfigs } from './request-util';
 
@@ -91,7 +91,7 @@ export class RequestController<Resource> {
     this.config.interceptors.beforeConsume(this.request);
 
     const tools: FetchTools = {
-      abortTools: this.config.abortTools,
+      abort: this.config.abort,
       interceptors: this.config.interceptors,
       retry: this.config.retry,
       retryCb: observer?.retry,
@@ -132,7 +132,7 @@ export class RequestController<Resource> {
         }
       })
       .catch((err: any) => {
-        if (this.config.abortTools.signal.aborted) return observer.abort?.(this.config.abortTools.signal.reason);
+        if (this.config.abort.signal.aborted) return observer.abort?.(this.config.abort.signal.reason);
         observer.error?.(err);
       })
       .finally(() => {
@@ -143,8 +143,8 @@ export class RequestController<Resource> {
 
   /** @internal */
   private catchable(thrown: any): Promise<any> {
-    const error: any = (this.config.abortTools.signal.aborted) ?
-      (this.config.abortTools.signal.abortedByTimeout) ? fixChromiumAndWebkitTimeoutError(thrown)
+    const error: any = (this.config.abort.signal.aborted) ?
+      (this.config.abort.signal.abortedByTimeout) ? fixChromiumAndWebkitTimeoutError(thrown)
         : fixFirefoxAbortError(thrown)
       : thrown;
 

--- a/src/request/request-util.ts
+++ b/src/request/request-util.ts
@@ -85,7 +85,7 @@ export function mergeRequestConfigs(requestConfig: RequestConfig<any, any>, defa
       onStatus: onStatus ?? instanceOnStatus,
       onMethods: instanceOnMethods,
     },
-    abortTools: (timeoutMs) ? mergeSignals(signal, timedSignal(timeoutMs))
+    abort: (timeoutMs) ? mergeSignals(signal, timedSignal(timeoutMs))
       : (instanceTimeoutMs) ? mergeSignals(signal, timedSignal(instanceTimeoutMs))
         : mergeSignals(signal),
   };

--- a/src/request/request-util.ts
+++ b/src/request/request-util.ts
@@ -85,7 +85,7 @@ export function mergeRequestConfigs(requestConfig: RequestConfig<any, any>, defa
       onStatus: onStatus ?? instanceOnStatus,
       onMethods: instanceOnMethods,
     },
-    abort: (timeoutMs) ? mergeSignals(signal, timedSignal(timeoutMs))
+    abortCtrl: (timeoutMs) ? mergeSignals(signal, timedSignal(timeoutMs))
       : (instanceTimeoutMs) ? mergeSignals(signal, timedSignal(instanceTimeoutMs))
         : mergeSignals(signal),
   };

--- a/src/utils/promise-util.ts
+++ b/src/utils/promise-util.ts
@@ -1,3 +1,3 @@
 export function sleep(durationMs: number): Promise<void> {
-  return new Promise(r => setTimeout(() => r(), durationMs));
+  return new Promise(r => setTimeout(r, durationMs));
 }

--- a/tests/units/features/abort/abort-util.spec.ts
+++ b/tests/units/features/abort/abort-util.spec.ts
@@ -1,5 +1,6 @@
-import { defaultSignal, timedSignal } from '../../../../src/features/abort/abort-util';
-import { expectProperty, expectType } from '../../../fixtures/utils/expect-util';
+import { defaultSignal, mergeSignals, timedSignal } from '../../../../src/features/abort/abort-util';
+import { sleep } from '../../../../src/utils/promise-util';
+import { expectEqual, expectProperty, expectType } from '../../../fixtures/utils/expect-util';
 
 describe('Util - Abort', () => {
 
@@ -18,5 +19,42 @@ describe('Util - Abort', () => {
       expectType(signal, 'AbortSignal');
       expectProperty(signal, 'hasTimeout', 'boolean', true);
     });
+  });
+
+  describe('mergeSignals', () => {
+
+    it('should return an aborted signal', () => {
+      const abortCtrl1: AbortController = new AbortController();
+      const abortCtrl2: AbortController = new AbortController();
+
+      const reason: string = 'reason';
+
+      abortCtrl1.abort(reason);
+
+      const { signal } = mergeSignals(abortCtrl1.signal, abortCtrl2.signal);
+
+      expectEqual(signal.aborted, true);
+      expectEqual(signal.reason, reason);
+    });
+
+    it('should abort because of timeout', async () => {
+      const signal1: AbortSignal = new AbortController().signal;
+      const signal2: AbortSignal = timedSignal(0);
+
+      await sleep(0);
+
+      const { signal } = mergeSignals(signal1, signal2);
+
+      expectEqual(signal.aborted, true);
+      expectEqual(signal.abortedByTimeout, true);
+    });
+  });
+
+  describe('fixFirefoxAbortError', () => {
+
+  });
+
+  describe('fixFirefoxAbortError', () => {
+
   });
 });


### PR DESCRIPTION
- Isolate `FetchTools` model and change property.
- Remove `AbortTools` from `FetchTools`.