### PR TITLE
Fix CommonJS default import

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -14,9 +14,9 @@ const fileName = 'index';
  */
 function bundle(options) {
   return {
-    ...options,
     input: `./src/${fileName}.ts`,
-    external: ['thror']
+    external: ['thror'],
+    ...options,
   }
 }
 
@@ -28,8 +28,14 @@ export default [
         file: `./dist/cjs/${fileName}.cjs`,
         format: 'cjs',
         exports: 'named',
-        sourcemap: true
+        sourcemap: true,
+        outro: 'module.exports = exports.default;'
       },
+    ]
+  }),
+  bundle({
+    plugins: [esbuild(), terser(), bundleSize()],
+    output: [
       {
         file: `./dist/esm/${fileName}.mjs`,
         format: 'es',

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -9,8 +9,8 @@
       "DOM.Iterable"
     ],
     "baseUrl": "./",
-    "declarationDir": "./dist/types",
     "sourceMap": true,
+    "declaration": false,
     "moduleResolution": "node",
     "esModuleInterop": true,
     "isolatedModules": true,


### PR DESCRIPTION
Add `module.exports = exports.default;` at the end of CommonJS bundle (using Rollup `outro`) to allow importing `drino` default's export with `require`.

Before :

```js
const drino = require('drino').default;

const instance = drino.create({});
```


Now :

```js
const drino = require('drino');

const instance = drino.create({});
```